### PR TITLE
fix typo

### DIFF
--- a/owncloud/map.jinja
+++ b/owncloud/map.jinja
@@ -20,7 +20,7 @@
         'pkg_repo':  'deb http://download.opensuse.org/repositories/isv:/ownCloud:/community/xUbuntu_14.04/ /',
         'key_url': 'http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_14.04/Release.key',
     },
-    'saucy':
+    'saucy': {
         'pkg_repo': 'deb http://download.opensuse.org/repositories/isv:/ownCloud:/community/xUbuntu_13.10/ /',
         'key_url': 'http://download.opensuse.org/repositories/isv:ownCloud:community/xUbuntu_13.10/Release.key',
     },


### PR DESCRIPTION
Hello

Just fix a typo causing error

    - Rendering SLS 'base:owncloud' failed: Jinja syntax error: expected token ',', got ':'
    - formulas/owncloud-formula/owncloud/map.jinja(24):