### PR TITLE
feat(redis): allow to disable protected mode

### DIFF
--- a/owncloud/defaults.yaml
+++ b/owncloud/defaults.yaml
@@ -21,4 +21,5 @@ redis:
   service: redis
   php_pkg: php-redis
   config: /etc/redis/redis.conf
+  protected_mode: 'yes'
 salt_managed_config: {}

--- a/owncloud/redis.sls
+++ b/owncloud/redis.sls
@@ -24,6 +24,15 @@ owncloud_redis_config_port:
     - require:
       - pkg: owncloud_redis_pkg
 
+owncloud_redis_config_protected_mode:
+  file.replace:
+    - name: {{ redis.config }}
+    - pattern: ^protected-mode .*$
+    - repl: protected-mode {{ redis.protected_mode }}
+    - append_if_not_found: True
+    - require:
+      - pkg: owncloud_redis_pkg
+
 owncloud_redis_service:
   service.running:
     - name: {{ redis.service }}
@@ -31,6 +40,7 @@ owncloud_redis_service:
     - watch:
       - file: owncloud_redis_config_bind
       - file: owncloud_redis_config_port
+      - file: owncloud_redis_config_protected_mode
 
 owncloud_redis_php_pkg:
   pkg.installed:

--- a/pillar.example
+++ b/pillar.example
@@ -7,6 +7,10 @@ owncloud:
     # ...
     # see also: owncloud/defaults.yaml and owncloud/osfamilymap.yaml
 
+    redis:
+      # Set this to 'no', if your redis instance runs on a localhost address other than 127.0.0.1
+      protected_mode: 'yes'
+
   # Must be set in some situations
   mysql_root_password: SuperSecurePassword
   # Will fail if none is set


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

none

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Redis enables protected mode when listening on addresses other than 127.0.0.1.  
But if one wants to use (i.e.) 127.3.0.1, `protected-mode` must be set to `no` manually.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

https://github.com/alxwr/owncloud-formula/blob/master/pillar.example#L12

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
% salt --state-output=changes --state-verbose=False 'example.com' state.highstate
example.com:
----------
          ID: owncloud_redis_config_protected_mode
    Function: file.replace
        Name: /usr/local/etc/redis.conf
      Result: True
     Comment: Changes were made
     Started: 17:44:35.040649
    Duration: 34.951 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -85,7 +85,7 @@
                   # you are sure you want clients from other hosts to connect to Redis
                   # even if no authentication is configured, nor a specific set of interfaces
                   # are explicitly listed using the "bind" directive.
                  -protected-mode yes
                  +protected-mode no
                   
                   # Accept connections on the specified port, default is 6379 (IANA #815344).
                   # If port 0 is specified Redis will not listen on a TCP socket.
----------
          ID: owncloud_redis_service
    Function: service.running
        Name: redis
      Result: True
     Comment: Service restarted
     Started: 17:44:35.169231
    Duration: 140.194 ms
     Changes:   
              ----------
              redis:
                  True
----------
          ID: apache-service-running-restart
    Function: module.wait
        Name: service.restart
      Result: True
     Comment: Module function service.restart executed
     Started: 17:44:35.898209
    Duration: 358.411 ms
     Changes:   
              ----------
              ret:
                  True

Summary for example.com
--------------
Succeeded: 101 (changed=3)
Failed:      0
--------------
Total states run:     101
Total run time:    10.469 
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


